### PR TITLE
[CMakeLists.txt] Add BUILD_ARCH option, default to "native"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,16 +97,18 @@ endif ()
 # Avoid using O3
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 
-check_cxx_compiler_flag(-march=native HAS_MARCH)
+option(BUILD_ARCH "Specify build architecture target" "native")
+
+check_cxx_compiler_flag("-march=${BUILD_ARCH}" HAS_MARCH)
 if (HAS_MARCH)
-    message(STATUS "Using march=native")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+    message(STATUS "Using march=${BUILD_ARCH}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${BUILD_ARCH}")
 else ()
     # Work around Summit only have mcpu flag
-    check_cxx_compiler_flag(-mcpu=native HAS_MCPU)
+    check_cxx_compiler_flag("-mcpu=${BUILD_ARCH}" HAS_MCPU)
     if (HAS_MCPU)
-        message(STATUS "Using mcpu=native")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=native")
+        message(STATUS "Using mcpu=${BUILD_ARCH}")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=${BUILD_ARCH}")
     endif ()
 endif ()
 


### PR DESCRIPTION
When cmake is testing if the -march=native switch works, this may fail
with the combination of older compiler and newer build hardware. If this
occurs then the build can fail due to unsupported defaults in the
compiler.

This was experienced when attempting to build the library in a Spack
configuration with an older compiler.

To correct this the BUILD_ARCH option is added to the CMakeLists.txt
file at the root. If the option is not specified on the command line,
then "-march=native" and "-mcpu=native" are the default switches that
are tested.

When cmake is executed with the BUILD_ARCH option like this:

    cmake -DBUILD_ARCH=icelake-server ..

Then cmake will test the "-march=icelake-server" or
"-mcpu=icelake-server" options. This allows build systems such as Spack
to specify the architecture to build for regardless of the architecture
of the build system.