### PR TITLE
[weak/mmap.cu] Move #includes to fix cuda build error

### DIFF
--- a/weak/mmap.cu
+++ b/weak/mmap.cu
@@ -3,8 +3,6 @@
 // Experiments using unified memory (through ATS)
 //
 
-#include "stencils/fake.h"
-#include "stencils/stencils.h"
 #include <brick-cuda.h>
 #include <brick-mpi.h>
 #include <brick.h>
@@ -16,6 +14,8 @@
 #include "bitset.h"
 #include "stencils/cudaarray.h"
 #include "stencils/cudavfold.h"
+#include "stencils/fake.h"
+#include "stencils/stencils.h"
 #include <brickcompare.h>
 #include <multiarray.h>
 


### PR DESCRIPTION
Rewritten to move `#include` statements to the correct place in `weak/mmap.cu`