### PR TITLE
Only check OpenCL if CUDA enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,9 @@ endif()
 
 find_package(OpenMP REQUIRED)
 find_package(MPI)
-find_package(OpenCL 2.0)
+if (CMAKE_CUDA_COMPILER)
+  find_package(OpenCL 2.0)
+endif ()
 
 option(BRICK_USE_MEMFD "Using memfd instead of shm_open, supported on Linux >= 3.17 with \"CONFIG_MEMFD_CREATE\"" OFF)
 if (BRICK_USE_MEMFD)


### PR DESCRIPTION
During the initial CMake configuration for this project, the OpenCL header would be detected, but the proper configuration would not be set for the build. This caused a failed attempt to build /stencils/3axis_cl.cpp because CL/opencl.hpp could not be found.

This is resolved when CUDA is installed. When CMake detects the CUDA compiler and headers, the correct environment is set for OpenCL as well. A change was made to only attempt detection of OpenCL when CUDA was found.

This is likely a problem with the OpenCL detection within CMake and optimally would be fixed in that package. Combined with the fact that bricklib OpenCL currently only works with CUDA, the best place to make this fix was within this library.